### PR TITLE
install-jenkins: append group to jenkins user

### DIFF
--- a/provisioners/shell/scripts/50-install-jenkins.sh
+++ b/provisioners/shell/scripts/50-install-jenkins.sh
@@ -8,6 +8,6 @@ zypper --gpg-auto-import-keys refresh
 zypper --non-interactive install java-openjdk-headless
 zypper --non-interactive install --from Jenkins jenkins
 
-usermod --groups docker jenkins
+usermod --append --groups docker jenkins
 
 systemctl enable jenkins-proxy.socket


### PR DESCRIPTION
This should have no effect, but appending supplementary groups rather than clobbering any existing ones is usually what we want.